### PR TITLE
Implement presence API

### DIFF
--- a/Document/jp/implementation-status.md
+++ b/Document/jp/implementation-status.md
@@ -19,6 +19,7 @@
 - 2025-05-24 AI Assistant マップ表示コンポーネント実装
 - 2025-05-24 AI Assistant ルーティング設定とMapページ追加
 - 2025-05-24 AI Assistant 認証APIの基本実装
+- 2025-05-24 AI Assistant プレゼンスAPI実装
 
 # 説明
 PintHopアプリケーションの現在の実装状況を追跡するドキュメント。実装フェーズ、完了した作業、進行中の作業、および次のステップについて概要を説明します。
@@ -205,11 +206,13 @@ PintHop/
 │   │   │   │   ├── breweries.ts （空ファイル）
 │   │   │   │   ├── breweryController.ts （新規作成）
 │   │   │   │   └── authController.ts    （新規作成）
+│   │   │   │   └── presenceController.ts （新規作成）
 │   │   │   ├── middlewares/ （現在空のディレクトリ）
 │   │   │   └── routes/
 │   │   │       ├── breweries.ts （空ファイル）
 │   │   │       └── breweryRoutes.ts （新規作成）
 │   │   │       └── authRoutes.ts    （新規作成）
+│   │   │       └── presenceRoutes.ts    （新規作成）
 │   │   ├── app.ts （新規作成）
 │   │   ├── config/ （現在空のディレクトリ）
 │   │   ├── data/
@@ -221,6 +224,7 @@ PintHop/
 │   │   ├── models/
 │   │   │   ├── Brewery.ts （新規作成）
 │   │   │   └── User.ts    （新規作成）
+│   │   │   └── Presence.ts    （新規作成）
 │   │   ├── server.ts （新規作成）
 │   │   ├── services/ （現在空のディレクトリ）
 │   │   ├── socket/ （現在空のディレクトリ）

--- a/Document/jp/project-structure.md
+++ b/Document/jp/project-structure.md
@@ -11,6 +11,7 @@
 - 2025-05-24 AI Assistant BreweryMapコンポーネントを追加
 - 2025-05-24 AI Assistant Mapページとルーティング設定を追加
 - 2025-05-24 AI Assistant 認証APIファイル追加
+- 2025-05-24 AI Assistant プレゼンスAPIファイル追加
 
 # 説明
 PintHopアプリケーションのプロジェクト構造を定義するドキュメント。ディレクトリ構成、ファイル構造、および各コンポーネントの関係性を詳細に説明します。
@@ -139,6 +140,7 @@ backend/
 │   │   │   ├── breweries.js # ブルワリールート
 │   │   │   ├── beers.js     # ビールルート
 │   │   │   ├── checkins.js  # チェックインルート
+│   │   │   ├── presenceRoutes.ts # プレゼンスルート
 │   │   │   └── events.js    # イベントルート
 │   │   │
 │   │   ├── controllers/   # コントローラー
@@ -147,6 +149,7 @@ backend/
 │   │   │   ├── breweries.js # ブルワリーコントローラー
 │   │   │   ├── beers.js     # ビールコントローラー
 │   │   │   ├── checkins.js  # チェックインコントローラー
+│   │   │   ├── presenceController.ts # プレゼンスコントローラー
 │   │   │   └── events.js    # イベントコントローラー
 │   │   │
 │   │   └── middlewares/   # ミドルウェア
@@ -160,7 +163,7 @@ backend/
 │   │   ├── Brewery.js     # ブルワリーモデル
 │   │   ├── Beer.js        # ビールモデル
 │   │   ├── Checkin.js     # チェックインモデル
-│   │   ├── Presence.js    # プレゼンスモデル
+│   │   ├── Presence.ts    # プレゼンスモデル
 │   │   ├── TapList.js     # タップリストモデル
 │   │   ├── Event.js       # イベントモデル
 │   │   └── Badge.js       # バッジモデル
@@ -214,6 +217,7 @@ backend/
 │   └── fixtures/        # テスト用データ
 │   └── breweryRoutes.test.ts # ブルワリールートテスト
 │   └── authRoutes.test.ts    # 認証ルートテスト
+│   └── presenceRoutes.test.ts # プレゼンスルートテスト
 │
 ├── .env.example         # 環境変数サンプル
 ├── .gitignore           # Gitの除外ファイル設定

--- a/backend/src/api/controllers/presenceController.ts
+++ b/backend/src/api/controllers/presenceController.ts
@@ -1,0 +1,53 @@
+/**
+ * プロジェクト: PintHop
+ * ファイルパス: backend/src/api/controllers/presenceController.ts
+ *
+ * 作成者: AI Assistant
+ * 作成日: 2025-05-24 00:00:00
+ *
+ * 更新履歴:
+ * - 2025-05-24 00:00:00 AI Assistant 新規作成
+ *
+ * 説明:
+ * プレゼンスAPIコントローラー
+ */
+
+import { Request, Response } from 'express';
+import Presence from '../../models/Presence';
+
+export const updatePresence = async (req: Request, res: Response) => {
+  try {
+    const userId = req.body.userId || req.user?.id; // req.userは認証ミドルウェアで設定される想定
+    if (!userId) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    const data = {
+      status: req.body.status,
+      location: req.body.location,
+      brewery: req.body.breweryId,
+      visibility: req.body.visibility
+    };
+    const presence = await Presence.findOneAndUpdate(
+      { user: userId },
+      { ...data, lastUpdated: new Date() },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+    res.json(presence);
+  } catch (err) {
+    console.error('Presence update error:', err);
+    res.status(500).json({ error: 'Failed to update presence' });
+  }
+};
+
+export const getFriendsPresence = async (req: Request, res: Response) => {
+  try {
+    const userId = req.user?.id;
+    const presences = await Presence.find({ user: { $ne: userId } })
+      .populate('brewery', 'name')
+      .limit(20);
+    res.json(presences);
+  } catch (err) {
+    console.error('Friends presence error:', err);
+    res.status(500).json({ error: 'Failed to get friends presence' });
+  }
+};

--- a/backend/src/api/routes/presenceRoutes.ts
+++ b/backend/src/api/routes/presenceRoutes.ts
@@ -1,0 +1,23 @@
+/**
+ * プロジェクト: PintHop
+ * ファイルパス: backend/src/api/routes/presenceRoutes.ts
+ *
+ * 作成者: AI Assistant
+ * 作成日: 2025-05-24 00:00:00
+ *
+ * 更新履歴:
+ * - 2025-05-24 00:00:00 AI Assistant 新規作成
+ *
+ * 説明:
+ * プレゼンスAPIのルート定義
+ */
+
+import express from 'express';
+import * as presenceController from '../controllers/presenceController';
+
+const router = express.Router();
+
+router.post('/', presenceController.updatePresence);
+router.get('/friends', presenceController.getFriendsPresence);
+
+export default router;

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -19,6 +19,7 @@ import morgan from 'morgan';
 import dotenv from 'dotenv';
 import breweryRoutes from './api/routes/breweryRoutes';
 import authRoutes from './api/routes/authRoutes';
+import presenceRoutes from './api/routes/presenceRoutes';
 
 // 環境変数の読み込み
 dotenv.config();
@@ -39,6 +40,7 @@ app.use(morgan('dev'));
 // APIルート
 app.use('/api/v1/auth', authRoutes);
 app.use('/api/v1/breweries', breweryRoutes);
+app.use('/api/v1/presence', presenceRoutes);
 
 // ヘルスチェックエンドポイント
 app.get('/health', (req: Request, res: Response) => {

--- a/backend/src/models/Presence.ts
+++ b/backend/src/models/Presence.ts
@@ -1,0 +1,85 @@
+/**
+ * プロジェクト: PintHop
+ * ファイルパス: backend/src/models/Presence.ts
+ *
+ * 作成者: AI Assistant
+ * 作成日: 2025-05-24 00:00:00
+ *
+ * 更新履歴:
+ * - 2025-05-24 00:00:00 AI Assistant 新規作成
+ *
+ * 説明:
+ * プレゼンス情報のMongooseモデル定義
+ */
+
+import mongoose, { Document, Model } from 'mongoose';
+
+export interface PresenceDocument extends Document {
+  user: mongoose.Types.ObjectId;
+  status: 'online' | 'away' | 'offline';
+  location?: {
+    type: string;
+    coordinates: [number, number];
+    accuracy?: number;
+  };
+  brewery?: mongoose.Types.ObjectId;
+  visibility: 'everyone' | 'friends' | 'none';
+  lastUpdated: Date;
+  expiresAt?: Date;
+}
+
+const presenceSchema = new mongoose.Schema<PresenceDocument>(
+  {
+    user: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      unique: true
+    },
+    status: {
+      type: String,
+      enum: ['online', 'away', 'offline'],
+      default: 'online'
+    },
+    location: {
+      type: {
+        type: String,
+        enum: ['Point'],
+        default: 'Point'
+      },
+      coordinates: [Number],
+      accuracy: Number
+    },
+    brewery: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Brewery'
+    },
+    lastUpdated: {
+      type: Date,
+      default: Date.now
+    },
+    visibility: {
+      type: String,
+      enum: ['everyone', 'friends', 'none'],
+      default: 'friends'
+    },
+    expiresAt: {
+      type: Date,
+      expires: 3600
+    }
+  },
+  { timestamps: true }
+);
+
+presenceSchema.index({ user: 1 }, { unique: true });
+presenceSchema.index({ location: '2dsphere' });
+presenceSchema.index({ brewery: 1 });
+presenceSchema.index({ lastUpdated: 1 });
+presenceSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+const Presence: Model<PresenceDocument> = mongoose.model<PresenceDocument>(
+  'Presence',
+  presenceSchema
+);
+
+export default Presence;

--- a/backend/tests/presenceRoutes.test.ts
+++ b/backend/tests/presenceRoutes.test.ts
@@ -1,0 +1,28 @@
+import request from 'supertest';
+import app from '../src/app';
+import Presence from '../src/models/Presence';
+
+jest.mock('../src/models/Presence');
+
+const mockPresence = { user: 'u1', status: 'online' };
+
+(Presence.findOneAndUpdate as jest.Mock).mockResolvedValue(mockPresence);
+(Presence.find as jest.Mock).mockResolvedValue([mockPresence]);
+
+describe('POST /api/v1/presence', () => {
+  it('test_updatePresence_validData_returnsPresence', async () => {
+    const res = await request(app)
+      .post('/api/v1/presence')
+      .send({ userId: 'u1', status: 'online' });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockPresence);
+  });
+});
+
+describe('GET /api/v1/presence/friends', () => {
+  it('test_getFriendsPresence_returnsList', async () => {
+    const res = await request(app).get('/api/v1/presence/friends');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([mockPresence]);
+  });
+});


### PR DESCRIPTION
## Summary
- add `Presence` mongoose model and controllers
- expose presence routes in Express app
- update docs with new presence API files
- add tests for presence routes

## Testing
- `npm --prefix backend test` *(fails: jest not found)*