### PR TITLE
Add presence context

### DIFF
--- a/Document/jp/implementation-status.md
+++ b/Document/jp/implementation-status.md
@@ -25,6 +25,7 @@
 - 2025-05-25 Codex BreweryCardコンポーネント追加
 - 2025-05-25 Codex AuthContextとuseAuthフック追加
 - 2025-05-26 Codex useGeolocationフック追加
+- 2025-05-27 Koki Riho and Codex PresenceContextとusePresenceフック追加
 
 # 説明
 PintHopアプリケーションの現在の実装状況を追跡するドキュメント。実装フェーズ、完了した作業、進行中の作業、および次のステップについて概要を説明します。
@@ -183,12 +184,15 @@ PintHop/
 │   │   │   │   └── FriendsPresenceList.tsx （新規作成）
 │   │   │   └── user/ （新規作成、現在空のディレクトリ）
 │   │   ├── context/
-│   │   │   └── AuthContext.tsx （新規作成）
+│   │   │   ├── AuthContext.tsx （新規作成）
+│   │   │   ├── PresenceContext.tsx （新規作成）
+│   │   │   └── test_PresenceContext_update_flow.tsx （新規作成）
 │   │   ├── hooks/
 │   │   │   ├── useFriendsPresence.ts （新規作成）
 │   │   │   ├── useBreweries.ts （新規作成）
-│   │   │   └── useAuth.ts （新規作成）
-│   │   │   └── useGeolocation.ts （新規作成）
+│   │   │   ├── useAuth.ts （新規作成）
+│   │   │   ├── useGeolocation.ts （新規作成）
+│   │   │   ├── usePresence.ts （新規作成）
 │   │   │   └── test_useGeolocation_updates_position.tsx （新規作成）
 │   │   ├── index.css （新規作成）
 │   │   ├── index.tsx （新規作成）

--- a/Document/jp/project-structure.md
+++ b/Document/jp/project-structure.md
@@ -17,6 +17,7 @@
 - 2025-05-25 Codex BreweryCardコンポーネント追加
 - 2025-05-25 Codex AuthContextコンポーネントと認証サービス追加
 - 2025-05-26 Codex useGeolocationフック追加
+- 2025-05-27 Koki Riho and Codex PresenceContextとusePresenceフック追加
 
 # 説明
 PintHopアプリケーションのプロジェクト構造を定義するドキュメント。ディレクトリ構成、ファイル構造、および各コンポーネントの関係性を詳細に説明します。

--- a/frontend/src/context/PresenceContext.tsx
+++ b/frontend/src/context/PresenceContext.tsx
@@ -1,0 +1,49 @@
+/**
+ * プロジェクト: PintHop
+ * ファイルパス: frontend/src/context/PresenceContext.tsx
+ *
+ * 作成者: Koki Riho and Codex
+ * 作成日: 2025-05-27 00:00:00
+ *
+ * 更新履歴:
+ * - 2025-05-27 00:00:00 Koki Riho and Codex 新規作成
+ *
+ * 説明:
+ * プレゼンス情報を管理するReactコンテキスト
+ */
+
+import React, { createContext, useState } from 'react';
+import { Presence } from '../types/presence';
+import { updatePresence as apiUpdatePresence, UpdatePresenceData } from '../services/presence';
+
+interface PresenceContextValue {
+  presence: Presence | null;
+  updatePresence: (data: UpdatePresenceData) => Promise<void>;
+}
+
+const PresenceContext = createContext<PresenceContextValue | undefined>(undefined);
+
+export const PresenceProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [presence, setPresence] = useState<Presence | null>(null);
+
+  const updatePresence = async (data: UpdatePresenceData) => {
+    const updated = await apiUpdatePresence(data);
+    setPresence(updated);
+  };
+
+  return (
+    <PresenceContext.Provider value={{ presence, updatePresence }}>
+      {children}
+    </PresenceContext.Provider>
+  );
+};
+
+export const usePresence = () => {
+  const ctx = React.useContext(PresenceContext);
+  if (!ctx) {
+    throw new Error('usePresence must be used within PresenceProvider');
+  }
+  return ctx;
+};
+
+export default PresenceContext;

--- a/frontend/src/context/test_PresenceContext_update_flow.tsx
+++ b/frontend/src/context/test_PresenceContext_update_flow.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { PresenceProvider, usePresence } from './PresenceContext';
+import * as presenceService from '../services/presence';
+
+jest.mock('../services/presence');
+
+const TestComponent: React.FC = () => {
+  const { presence, updatePresence } = usePresence();
+  return (
+    <div>
+      <button onClick={() => updatePresence({ status: 'online' })}>Update</button>
+      {presence && <span data-testid="status">{presence.status}</span>}
+    </div>
+  );
+};
+
+test('test_presenceContext_update_flow', async () => {
+  (presenceService.updatePresence as jest.Mock).mockResolvedValue({
+    user: '1',
+    status: 'online'
+  });
+
+  render(
+    <PresenceProvider>
+      <TestComponent />
+    </PresenceProvider>
+  );
+
+  fireEvent.click(screen.getByText('Update'));
+
+  await waitFor(() => {
+    expect(screen.getByTestId('status')).toHaveTextContent('online');
+    expect(presenceService.updatePresence).toHaveBeenCalledWith({ status: 'online' });
+  });
+});

--- a/frontend/src/hooks/usePresence.ts
+++ b/frontend/src/hooks/usePresence.ts
@@ -1,0 +1,26 @@
+/**
+ * プロジェクト: PintHop
+ * ファイルパス: frontend/src/hooks/usePresence.ts
+ *
+ * 作成者: Koki Riho and Codex
+ * 作成日: 2025-05-27 00:00:00
+ *
+ * 更新履歴:
+ * - 2025-05-27 00:00:00 Koki Riho and Codex 新規作成
+ *
+ * 説明:
+ * PresenceContextを利用するためのカスタムフック
+ */
+
+import { useContext } from 'react';
+import PresenceContext from '../context/PresenceContext';
+
+const usePresence = () => {
+  const ctx = useContext(PresenceContext);
+  if (!ctx) {
+    throw new Error('usePresence must be used within PresenceProvider');
+  }
+  return ctx;
+};
+
+export default usePresence;

--- a/frontend/src/services/presence.ts
+++ b/frontend/src/services/presence.ts
@@ -2,11 +2,12 @@
  * プロジェクト: PintHop
  * ファイルパス: frontend/src/services/presence.ts
  *
- * 作成者: Koki Riho
+ * 作成者: Koki Riho and Codex
  * 作成日: 2025-05-24 00:00:00
  *
  * 更新履歴:
  * - 2025-05-24 00:00:00 Koki Riho 新規作成
+ * - 2025-05-27 00:00:00 Koki Riho and Codex updatePresence関数追加
  *
  * 説明:
  * プレゼンスデータ取得サービス
@@ -20,4 +21,21 @@ const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
 export const fetchFriendsPresence = async (): Promise<Presence[]> => {
   const response = await axios.get(`${API_URL}/v1/presence/friends`);
   return response.data as Presence[];
+};
+
+export interface UpdatePresenceData {
+  status?: 'online' | 'away' | 'offline';
+  location?: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+  breweryId?: string;
+  visibility?: 'everyone' | 'friends' | 'none';
+}
+
+export const updatePresence = async (
+  data: UpdatePresenceData
+): Promise<Presence> => {
+  const response = await axios.post(`${API_URL}/v1/presence`, data);
+  return response.data as Presence;
 };


### PR DESCRIPTION
## Summary
- add `PresenceContext` and `usePresence` hook for managing own presence
- extend presence service with `updatePresence`
- document the new files in project structure and implementation status
- include tests for PresenceContext

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*