### PR TITLE
Implement brewery presence endpoint and hook

### DIFF
--- a/Document/jp/api-document.md
+++ b/Document/jp/api-document.md
@@ -12,6 +12,7 @@
 - 2025-05-24 AI Assistant ランダムブルワリー取得API追加
 - 2025-05-24 AI Assistant チェックインAPI実装
 - 2025-05-28 Koki Riho and Codex 自分のプレゼンス取得API追加
+- 2025-05-29 Koki Riho and Codex ブルワリーのプレゼンス取得API追加
 
 # 説明
 PintHopアプリケーションのAPIインターフェース仕様を定義するドキュメント。各エンドポイント、リクエスト/レスポンス形式、認証方法、およびWebSocketイベントを詳細に説明します。

--- a/Document/jp/implementation-status.md
+++ b/Document/jp/implementation-status.md
@@ -27,6 +27,7 @@
 - 2025-05-26 Codex useGeolocationフック追加
 - 2025-05-27 Koki Riho and Codex PresenceContextとusePresenceフック追加
 - 2025-05-28 Koki Riho and Codex 自分のプレゼンス取得API追加
+- 2025-05-29 Koki Riho and Codex ブルワリーのプレゼンス取得API追加
 
 # 説明
 PintHopアプリケーションの現在の実装状況を追跡するドキュメント。実装フェーズ、完了した作業、進行中の作業、および次のステップについて概要を説明します。

--- a/Document/jp/project-structure.md
+++ b/Document/jp/project-structure.md
@@ -19,6 +19,7 @@
 - 2025-05-26 Codex useGeolocationフック追加
 - 2025-05-27 Koki Riho and Codex PresenceContextとusePresenceフック追加
 - 2025-05-28 Koki Riho and Codex presenceRoutesに/meエンドポイント追加
+- 2025-05-29 Koki Riho and Codex useBreweryPresenceフック追加
 
 # 説明
 PintHopアプリケーションのプロジェクト構造を定義するドキュメント。ディレクトリ構成、ファイル構造、および各コンポーネントの関係性を詳細に説明します。
@@ -92,6 +93,7 @@ frontend/
 │   │   ├── usePresence.ts     # プレゼンス関連フック
 │   │   ├── useFriendsPresence.ts # 友達プレゼンス取得フック
 │   │   ├── useBreweries.ts    # ブルワリーデータフック
+│   │   ├── useBreweryPresence.ts # ブルワリーごとのプレゼンスフック
 │   │   └── useGeolocation.ts  # 位置情報フック
 │   │
 │   ├── pages/           # 画面コンポーネント

--- a/backend/src/api/controllers/presenceController.ts
+++ b/backend/src/api/controllers/presenceController.ts
@@ -8,6 +8,7 @@
  * 更新履歴:
  * - 2025-05-24 00:00:00 AI Assistant 新規作成
  * - 2025-05-28 00:00:00 Koki Riho and Codex getMyPresence追加
+ * - 2025-05-29 00:00:00 Koki Riho and Codex getPresenceByBrewery追加
  *
  * 説明:
  * プレゼンスAPIコントローラー
@@ -67,6 +68,22 @@ export const getMyPresence = async (req: Request, res: Response) => {
   } catch (err) {
     console.error('Get my presence error:', err);
     res.status(500).json({ error: 'Failed to get presence' });
+  }
+};
+
+export const getPresenceByBrewery = async (
+  req: Request,
+  res: Response
+) => {
+  try {
+    const { breweryId } = req.params;
+    const presences = await Presence.find({ brewery: breweryId })
+      .populate('user', 'username')
+      .populate('brewery', 'name');
+    res.json(presences);
+  } catch (err) {
+    console.error('Get brewery presence error:', err);
+    res.status(500).json({ error: 'Failed to get brewery presence' });
   }
 };
 

--- a/backend/src/api/routes/breweryRoutes.ts
+++ b/backend/src/api/routes/breweryRoutes.ts
@@ -8,6 +8,7 @@
  * 更新履歴:
  * - 2025-05-04 00:00:00 Koki Riho 初期作成
  * - 2025-05-24 20:15:50 AI Assistant ランダム取得エンドポイント追加
+ * - 2025-05-29 00:00:00 Koki Riho and Codex ブルワリーのプレゼンス取得エンドポイント追加
  *
  * 説明:
  * ブルワリーAPIのルート定義
@@ -15,6 +16,7 @@
 
 import express from 'express';
 import * as breweryController from '../controllers/breweryController';
+import * as presenceController from '../controllers/presenceController';
 
 const router = express.Router();
 
@@ -24,5 +26,6 @@ router.get('/random', breweryController.getRandomBrewery);
 router.get('/nearby', breweryController.getNearbyBreweries);
 router.get('/region/:region', breweryController.getBreweriesByRegion);
 router.get('/:id', breweryController.getBreweryById);
+router.get('/:breweryId/presence', presenceController.getPresenceByBrewery);
 
 export default router;

--- a/backend/tests/breweryRoutes.test.ts
+++ b/backend/tests/breweryRoutes.test.ts
@@ -1,12 +1,17 @@
 import request from 'supertest';
 import app from '../src/app';
 import Brewery from '../src/models/Brewery';
+import Presence from '../src/models/Presence';
 
 jest.mock('../src/models/Brewery');
+jest.mock('../src/models/Presence');
 
-const mockBreweries = [{ name: 'Test Brewery' }];
+const mockBreweries = [{ name: 'Test Brewery', _id: 'b1' }];
 (Brewery.find as jest.Mock).mockResolvedValue(mockBreweries);
 (Brewery.aggregate as jest.Mock).mockResolvedValue([mockBreweries[0]]);
+
+const mockPresence = [{ user: 'u1', status: 'online', brewery: 'b1' }];
+(Presence.find as jest.Mock).mockResolvedValue(mockPresence);
 
 describe('GET /api/v1/breweries', () => {
   it('should return breweries list', async () => {
@@ -21,5 +26,13 @@ describe('GET /api/v1/breweries/random', () => {
     const res = await request(app).get('/api/v1/breweries/random');
     expect(res.status).toBe(200);
     expect(res.body).toEqual(mockBreweries[0]);
+  });
+});
+
+describe('GET /api/v1/breweries/:id/presence', () => {
+  it('should return presence list for brewery', async () => {
+    const res = await request(app).get('/api/v1/breweries/b1/presence');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockPresence);
   });
 });

--- a/frontend/src/hooks/test_useBreweryPresence_fetches_data.tsx
+++ b/frontend/src/hooks/test_useBreweryPresence_fetches_data.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { useBreweryPresence } from './useBreweryPresence';
+import * as presenceService from '../services/presence';
+import { Presence } from '../types/presence';
+
+jest.mock('../services/presence');
+
+const mockPresence: Presence[] = [{ user: 'u1', status: 'online', brewery: 'b1' }];
+(presenceService.fetchBreweryPresence as jest.Mock).mockResolvedValue(mockPresence);
+
+const TestComponent: React.FC = () => {
+  const { presences, loading } = useBreweryPresence('b1');
+  if (loading) return <div>loading</div>;
+  return <span data-testid="count">{presences.length}</span>;
+};
+
+test('test_useBreweryPresence_fetches_data', async () => {
+  render(<TestComponent />);
+  await waitFor(() => expect(screen.getByTestId('count')).toHaveTextContent('1'));
+});

--- a/frontend/src/hooks/useBreweryPresence.ts
+++ b/frontend/src/hooks/useBreweryPresence.ts
@@ -1,0 +1,38 @@
+/**
+ * プロジェクト: PintHop
+ * ファイルパス: frontend/src/hooks/useBreweryPresence.ts
+ *
+ * 作成者: Koki Riho and Codex
+ * 作成日: 2025-05-29 00:00:00
+ *
+ * 更新履歴:
+ * - 2025-05-29 00:00:00 Koki Riho and Codex 新規作成
+ *
+ * 説明:
+ * 指定ブルワリーのプレゼンス取得用カスタムフック
+ */
+
+import { useEffect, useState } from 'react';
+import { Presence } from '../types/presence';
+import { fetchBreweryPresence } from '../services/presence';
+
+export const useBreweryPresence = (breweryId: string) => {
+  const [presences, setPresences] = useState<Presence[]>([]);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchBreweryPresence(breweryId);
+        setPresences(data);
+      } catch (err) {
+        console.error('Failed to fetch brewery presence', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [breweryId]);
+
+  return { presences, loading };
+};

--- a/frontend/src/services/presence.ts
+++ b/frontend/src/services/presence.ts
@@ -8,6 +8,7 @@
  * 更新履歴:
  * - 2025-05-24 00:00:00 Koki Riho 新規作成
  * - 2025-05-27 00:00:00 Koki Riho and Codex updatePresence関数追加
+ * - 2025-05-29 00:00:00 Koki Riho and Codex fetchBreweryPresence関数追加
  *
  * 説明:
  * プレゼンスデータ取得サービス
@@ -20,6 +21,15 @@ const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5000/api';
 
 export const fetchFriendsPresence = async (): Promise<Presence[]> => {
   const response = await axios.get(`${API_URL}/v1/presence/friends`);
+  return response.data as Presence[];
+};
+
+export const fetchBreweryPresence = async (
+  breweryId: string
+): Promise<Presence[]> => {
+  const response = await axios.get(
+    `${API_URL}/v1/breweries/${breweryId}/presence`
+  );
   return response.data as Presence[];
 };
 


### PR DESCRIPTION
## Summary
- add `getPresenceByBrewery` controller and route
- support fetching brewery presence in frontend service
- create `useBreweryPresence` hook with tests
- test backend route for brewery presence
- document new files and API in project docs

## Testing
- `npm test` *(fails: jest not found)*