### PR TITLE
Phase0 presence context init

### DIFF
--- a/Document/jp/implementation-status.md
+++ b/Document/jp/implementation-status.md
@@ -28,6 +28,7 @@
 - 2025-05-27 Koki Riho and Codex PresenceContextとusePresenceフック追加
 - 2025-05-28 Koki Riho and Codex 自分のプレゼンス取得API追加
 - 2025-05-29 Koki Riho and Codex ブルワリーのプレゼンス取得API追加
+- 2025-05-30 Koki Riho and Codex PresenceContext初期プレゼンス取得ロジック追加
 
 # 説明
 PintHopアプリケーションの現在の実装状況を追跡するドキュメント。実装フェーズ、完了した作業、進行中の作業、および次のステップについて概要を説明します。
@@ -189,6 +190,7 @@ PintHop/
 │   │   │   ├── AuthContext.tsx （新規作成）
 │   │   │   ├── PresenceContext.tsx （新規作成）
 │   │   │   └── test_PresenceContext_update_flow.tsx （新規作成）
+│   │   │   └── test_PresenceContext_initial_fetch.tsx （新規作成）
 │   │   ├── hooks/
 │   │   │   ├── useFriendsPresence.ts （新規作成）
 │   │   │   ├── useBreweries.ts （新規作成）

--- a/Document/jp/project-structure.md
+++ b/Document/jp/project-structure.md
@@ -20,6 +20,7 @@
 - 2025-05-27 Koki Riho and Codex PresenceContextとusePresenceフック追加
 - 2025-05-28 Koki Riho and Codex presenceRoutesに/meエンドポイント追加
 - 2025-05-29 Koki Riho and Codex useBreweryPresenceフック追加
+- 2025-05-30 Koki Riho and Codex PresenceContext初期プレゼンス取得ロジック追加
 
 # 説明
 PintHopアプリケーションのプロジェクト構造を定義するドキュメント。ディレクトリ構成、ファイル構造、および各コンポーネントの関係性を詳細に説明します。

--- a/frontend/src/context/PresenceContext.tsx
+++ b/frontend/src/context/PresenceContext.tsx
@@ -7,14 +7,19 @@
  *
  * 更新履歴:
  * - 2025-05-27 00:00:00 Koki Riho and Codex 新規作成
+ * - 2025-05-30 00:00:00 Koki Riho and Codex 初期プレゼンス取得処理追加
  *
  * 説明:
  * プレゼンス情報を管理するReactコンテキスト
  */
 
-import React, { createContext, useState } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
 import { Presence } from '../types/presence';
-import { updatePresence as apiUpdatePresence, UpdatePresenceData } from '../services/presence';
+import {
+  updatePresence as apiUpdatePresence,
+  fetchMyPresence,
+  UpdatePresenceData
+} from '../services/presence';
 
 interface PresenceContextValue {
   presence: Presence | null;
@@ -25,6 +30,18 @@ const PresenceContext = createContext<PresenceContextValue | undefined>(undefine
 
 export const PresenceProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [presence, setPresence] = useState<Presence | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchMyPresence();
+        setPresence(data);
+      } catch (err) {
+        console.error('Failed to fetch my presence', err);
+      }
+    };
+    load();
+  }, []);
 
   const updatePresence = async (data: UpdatePresenceData) => {
     const updated = await apiUpdatePresence(data);

--- a/frontend/src/context/test_PresenceContext_initial_fetch.tsx
+++ b/frontend/src/context/test_PresenceContext_initial_fetch.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { PresenceProvider, usePresence } from './PresenceContext';
+import * as presenceService from '../services/presence';
+
+jest.mock('../services/presence');
+
+const TestComponent: React.FC = () => {
+  const { presence } = usePresence();
+  return <span data-testid="status">{presence?.status}</span>;
+};
+
+test('test_presenceContext_initial_fetch', async () => {
+  (presenceService.fetchMyPresence as jest.Mock).mockResolvedValue({
+    user: '1',
+    status: 'online'
+  });
+
+  render(
+    <PresenceProvider>
+      <TestComponent />
+    </PresenceProvider>
+  );
+
+  await waitFor(() =>
+    expect(screen.getByTestId('status')).toHaveTextContent('online')
+  );
+});
+

--- a/frontend/src/services/presence.ts
+++ b/frontend/src/services/presence.ts
@@ -9,6 +9,7 @@
  * - 2025-05-24 00:00:00 Koki Riho 新規作成
  * - 2025-05-27 00:00:00 Koki Riho and Codex updatePresence関数追加
  * - 2025-05-29 00:00:00 Koki Riho and Codex fetchBreweryPresence関数追加
+ * - 2025-05-30 00:00:00 Koki Riho and Codex fetchMyPresence関数追加
  *
  * 説明:
  * プレゼンスデータ取得サービス
@@ -47,5 +48,10 @@ export const updatePresence = async (
   data: UpdatePresenceData
 ): Promise<Presence> => {
   const response = await axios.post(`${API_URL}/v1/presence`, data);
+  return response.data as Presence;
+};
+
+export const fetchMyPresence = async (): Promise<Presence> => {
+  const response = await axios.get(`${API_URL}/v1/presence/me`);
   return response.data as Presence;
 };


### PR DESCRIPTION
## Summary
- fetch user's own presence from API
- initialize PresenceContext with fetched presence
- cover new behavior with tests
- document new files in project structure and implementation status

## Testing
- `npm --prefix frontend test -- -w=1` *(fails: react-scripts not found)*
- `npm --prefix backend test` *(fails: jest not found)*