### PR TITLE
Add logger utility with tests

### DIFF
--- a/Document/jp/implementation-status.md
+++ b/Document/jp/implementation-status.md
@@ -30,6 +30,7 @@
 - 2025-05-29 Koki Riho and Codex ブルワリーのプレゼンス取得API追加
 - 2025-05-30 Koki Riho and Codex PresenceContext初期プレゼンス取得ロジック追加
 - 2025-05-31 Koki Riho and Codex チェックインサービスとuseCheckinsフック追加
+- 2025-05-31 Koki Riho and Codex loggerユーティリティ追加とテスト実装
 
 # 説明
 PintHopアプリケーションの現在の実装状況を追跡するドキュメント。実装フェーズ、完了した作業、進行中の作業、および次のステップについて概要を説明します。

--- a/Document/jp/project-structure.md
+++ b/Document/jp/project-structure.md
@@ -22,6 +22,7 @@
 - 2025-05-29 Koki Riho and Codex useBreweryPresenceフック追加
 - 2025-05-30 Koki Riho and Codex PresenceContext初期プレゼンス取得ロジック追加
 - 2025-05-31 Koki Riho and Codex チェックインサービスとuseCheckinsフック追加
+- 2025-05-31 Koki Riho and Codex loggerユーティリティとテスト追加
 
 # 説明
 PintHopアプリケーションのプロジェクト構造を定義するドキュメント。ディレクトリ構成、ファイル構造、および各コンポーネントの関係性を詳細に説明します。
@@ -204,7 +205,7 @@ backend/
 │   │   └── seeds/         # シードデータ
 │   │
 │   ├── utils/           # ユーティリティ関数
-│   │   ├── logger.js      # ロギングユーティリティ
+│   │   ├── logger.ts      # ロギングユーティリティ
 │   │   ├── security.js    # セキュリティユーティリティ
 │   │   ├── validation.js  # バリデーションユーティリティ
 │   │   └── formatter.js   # フォーマットユーティリティ
@@ -237,6 +238,7 @@ backend/
 │   └── authRoutes.test.ts    # 認証ルートテスト
 │   └── presenceRoutes.test.ts # プレゼンスルートテスト
 │   └── checkinRoutes.test.ts  # チェックインルートテスト
+│   └── logger.test.ts         # ロガーテスト
 │
 ├── .env.example         # 環境変数サンプル
 ├── .gitignore           # Gitの除外ファイル設定

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -7,6 +7,7 @@
  * 
  * 更新履歴:
  * - 2025-05-04 00:00:00 Koki Riho 初期作成
+ * - 2025-05-31 00:00:00 Koki Riho and Codex logger適用
  *
  * 説明:
  * サーバーのエントリーポイント、HTTPサーバーの初期化とデータベース接続
@@ -16,6 +17,7 @@ import app from './app';
 import http from 'http';
 import mongoose from 'mongoose';
 import dotenv from 'dotenv';
+import logger from './utils/logger';
 
 // 環境変数の読み込み
 dotenv.config();
@@ -31,9 +33,9 @@ const connectDB = async () => {
   try {
     const mongoURI = process.env.MONGODB_URI as string;
     await mongoose.connect(mongoURI);
-    console.log('MongoDB connected successfully');
+    logger.info('MongoDB connected successfully');
   } catch (err) {
-    console.error('MongoDB connection error:', err);
+    logger.error('MongoDB connection error:', err);
     process.exit(1);
   }
 };
@@ -43,19 +45,19 @@ const startServer = async () => {
   await connectDB();
   
   server.listen(PORT, () => {
-    console.log(`Server running on port ${PORT}`);
-    console.log(`Environment: ${process.env.NODE_ENV}`);
+    logger.info(`Server running on port ${PORT}`);
+    logger.info(`Environment: ${process.env.NODE_ENV}`);
   });
 };
 
 // プロセスの例外ハンドリング
 process.on('uncaughtException', (err) => {
-  console.error('Uncaught Exception:', err);
+  logger.error('Uncaught Exception:', err);
   process.exit(1);
 });
 
 process.on('unhandledRejection', (err) => {
-  console.error('Unhandled Rejection:', err);
+  logger.error('Unhandled Rejection:', err);
   process.exit(1);
 });
 

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,0 +1,27 @@
+/**
+ * プロジェクト: PintHop
+ * ファイルパス: backend/src/utils/logger.ts
+ *
+ * 作成者: Koki Riho and Codex
+ * 作成日: 2025-05-31 00:00:00
+ *
+ * 更新履歴:
+ * - 2025-05-31 00:00:00 Koki Riho and Codex 新規作成
+ *
+ * 説明:
+ * コンソールラッパーによる単純なロギングユーティリティ
+ */
+
+export const logger = {
+  info: (message: string, ...optionalParams: unknown[]): void => {
+    console.log(message, ...optionalParams);
+  },
+  error: (message: string, ...optionalParams: unknown[]): void => {
+    console.error(message, ...optionalParams);
+  },
+  warn: (message: string, ...optionalParams: unknown[]): void => {
+    console.warn(message, ...optionalParams);
+  }
+};
+
+export default logger;

--- a/backend/tests/logger.test.ts
+++ b/backend/tests/logger.test.ts
@@ -1,0 +1,31 @@
+/**
+ * プロジェクト: PintHop
+ * ファイルパス: backend/tests/logger.test.ts
+ *
+ * 作成者: Koki Riho and Codex
+ * 作成日: 2025-05-31 00:00:00
+ *
+ * 更新履歴:
+ * - 2025-05-31 00:00:00 Koki Riho and Codex 新規作成
+ *
+ * 説明:
+ * loggerユーティリティのテスト
+ */
+
+import { logger } from '../src/utils/logger';
+
+describe('logger', () => {
+  it('test_logger_info_outputs_message', () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation();
+    logger.info('hello');
+    expect(spy).toHaveBeenCalledWith('hello');
+    spy.mockRestore();
+  });
+
+  it('test_logger_error_outputs_message', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+    logger.error('oops');
+    expect(spy).toHaveBeenCalledWith('oops');
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- implement simple logger utility for backend
- use logger in the server
- add logger tests
- document new logger utility in project structure
- update implementation status history

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm test --silent` in frontend *(fails: react-scripts not found)*